### PR TITLE
fix dropdown with template names if django_dbtemplates used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ override them in site-wide settings.py file. The main of them are:
   * FLATPAGES_TEMPLATE_DIR (default: TEMPLATE_DIRS[0] + 'flatpages') - directory where
     flatpages templates are placed
   * FLATPAGES USE_MINIFIED (defalut: not settings.DEBUG) - use minified versions of JS/CSS
+  * FLATPAGES_USE_DBTEMPLATES (default: False) - If you are using to store templates django_dbtemplates - set it  to True. In  dropdown list will be listed all templates from dbtemplates
 
 Further, you will want to change default settings of TinyMCE Editor.
 

--- a/flatpages_tinymce/admin.py
+++ b/flatpages_tinymce/admin.py
@@ -52,7 +52,7 @@ class FlatPageAdmin(flatpages_admin.FlatPageAdmin):
         if db_field.name == 'content':
             if settings.USE_ADMIN_AREA_TINYMCE:
                 new_field = db_field.formfield(widget=TinyMCE(
-                    attrs={'cols':  80, 'rows': 30},
+                    attrs=settings.TINYMCE_DEFAULT_CONFIG,
                     mce_attrs={'external_link_list_url': reverse('tinymce.views.flatpages_link_list')},
                 ))
         else:

--- a/flatpages_tinymce/settings.py
+++ b/flatpages_tinymce/settings.py
@@ -5,6 +5,7 @@ USE_ADMIN_AREA_TINYMCE = getattr(settings, "FLATPAGES_TINYMCE_ADMIN", True)
 USE_FRONTED_TINYMCE = getattr(settings, "FLATPAGES_TINYMCE_FRONTEND", True)
 
 USE_TEMPLATE_DROPDOWN = getattr(settings, "FLATPAGES_USE_TEMPLATE_DROPDOWN", True)
+USE_DBTEMPLATES = getattr(settings, "FLATPAGES_USE_DBTEMPLATES", False)
 TEMPLATE_DIR = getattr(settings, "FLATPAGES_TEMPLATE_DIR", os.path.join(settings.TEMPLATE_DIRS[0], 'flatpages'))
 TEMPLATE_FILES_REGEXP = getattr(settings, 'FLATPAGES_ADMIN_REGEXP', r'.*\.d?html?')
 

--- a/flatpages_tinymce/settings.py
+++ b/flatpages_tinymce/settings.py
@@ -6,6 +6,7 @@ USE_FRONTED_TINYMCE = getattr(settings, "FLATPAGES_TINYMCE_FRONTEND", True)
 
 USE_TEMPLATE_DROPDOWN = getattr(settings, "FLATPAGES_USE_TEMPLATE_DROPDOWN", True)
 USE_DBTEMPLATES = getattr(settings, "FLATPAGES_USE_DBTEMPLATES", False)
+TINYMCE_DEFAULT_CONFIG = getattr(settings, "TINYMCE_DEFAULT_CONFIG", {'cols':  80, 'rows': 30})
 TEMPLATE_DIR = getattr(settings, "FLATPAGES_TEMPLATE_DIR", os.path.join(settings.TEMPLATE_DIRS[0], 'flatpages'))
 TEMPLATE_FILES_REGEXP = getattr(settings, 'FLATPAGES_ADMIN_REGEXP', r'.*\.d?html?')
 


### PR DESCRIPTION
1) fix dropdown with template names if django_dbtemplates used
2) remove hardcoded default tinymce settings
