### PR TITLE
Django 1.6 changed the import of url

### DIFF
--- a/flatpages_tinymce/admin.py
+++ b/flatpages_tinymce/admin.py
@@ -10,7 +10,10 @@ from tinymce.widgets import TinyMCE
 from flatpages_tinymce import settings
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponse, Http404
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls.defaults import patterns, url
+except:
+    from django.conf.urls import patterns, url
 from django.views.decorators.csrf import csrf_protect
 
 


### PR DESCRIPTION
Fix the same bug as #9, but with a try-exceot
