### PR TITLE
django.conf.urls.defaults has been removed in d-1.6 changed django.co…

### DIFF
--- a/flatpages_tinymce/admin.py
+++ b/flatpages_tinymce/admin.py
@@ -10,7 +10,7 @@ from tinymce.widgets import TinyMCE
 from flatpages_tinymce import settings
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponse, Http404
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.views.decorators.csrf import csrf_protect
 
 


### PR DESCRIPTION
…nf.urls
